### PR TITLE
fix(http): adding compatibility patch for older releases

### DIFF
--- a/servc/svc/com/http/__init__.py
+++ b/servc/svc/com/http/__init__.py
@@ -127,6 +127,10 @@ class HTTPInterface(Middleware):
         if content_type == "application/json":
             body = request.json
 
+            # compatibility patch
+            if "inputs" in body and "argument" not in body:
+                body["argument"] = body["inputs"]
+
             must_have_keys = ("type",)
             for key in must_have_keys:
                 if key not in body:


### PR DESCRIPTION
http interface will accept payloads that were used in older releases like v0.6.x