### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: 'Unit Tests'
+permissions:
+  contents: read
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/serv-c/servc-python/security/code-scanning/1](https://github.com/serv-c/servc-python/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will specify the least privileges required for the workflow to function correctly. Since the workflow primarily involves checking out the repository and running tests, it only requires `contents: read` permissions. This ensures that the workflow cannot perform any unintended write operations.

The `permissions` block will be added immediately after the `name` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
