### PR TITLE
feat: upgrade deltalake from 0.25.5 to 1.1.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ simplejson==3.20.1
 flask==3.1.1
 pyyaml==6.0.2
 pyiceberg[sql-sqlite,pyarrow]==0.8.1
-deltalake==0.25.5
+deltalake==1.1.3
 azure-servicebus==7.14.2


### PR DESCRIPTION
Upgrades the deltalake package from version 0.25.5 to 1.1.3 as requested in issue #104.

## Changes
- Updated `requirements.txt` to use deltalake==1.1.3

## Compatibility
Analysis shows this is a low-risk upgrade as all deltalake APIs used in the codebase are stable core functionality:
- DeltaTable.create() operations
- write_deltalake() for append/overwrite
- Table optimization methods
- Read operations and time travel features

## Testing
The existing comprehensive test suite in `tests/test_delta.py` validates all delta functionality.

Closes #104

🤖 Generated with [Claude Code](https://claude.ai/code)