### PR TITLE
feat: upgrade deltalake from 0.25.5 to 1.1.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ simplejson==3.20.1
 flask==3.1.1
 pyyaml==6.0.2
 pyiceberg[sql-sqlite,pyarrow]==0.8.1
-deltalake==0.25.5
+deltalake==1.1.3
 azure-servicebus==7.14.2


### PR DESCRIPTION
Upgrades the deltalake package from version 0.25.5 to 1.1.3 as requested in issue #110.

This is a major version upgrade that includes performance improvements and potential API enhancements. The existing Delta storage implementation in `servc/svc/com/storage/delta.py` should remain compatible based on code analysis.

**Changes:**
- Updated `requirements.txt` to use deltalake==1.1.3

**Testing:**
- Unit tests in `tests/test_delta.py` will validate functionality
- mypy type checking will ensure type compatibility

**References:**
- Closes #110

🤖 Generated with [Claude Code](https://claude.ai/code)