### PR TITLE
docs: add unit testing instructions to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,8 +21,34 @@ The project includes type stubs and typing information:
 2. Run type checking: `mypy servc --check-untyped-defs`
 3. Fix any type issues before committing
 
+## Unit Testing with unittest
+
+### Setup
+This project uses Python's built-in unittest framework for testing. The coverage dependency is included in `requirements-dev.txt` for test coverage analysis.
+
+### Required Commands
+To enable full unit testing capabilities, Claude needs permission to run:
+- `python -m unittest discover tests` - Run all unit tests in the tests directory
+- `python -m unittest tests.test_config` - Run specific test module
+- `python -m coverage run -m unittest discover tests` - Run tests with coverage analysis
+- `python -m coverage report` - Display coverage report
+- `python -m coverage html` - Generate HTML coverage report
+
+### Test Structure
+The project includes comprehensive unit tests:
+- `tests/` directory contains all test files
+- Test files follow the `test_*.py` naming convention
+- Uses standard unittest.TestCase classes for test organization
+
+### Development Workflow
+1. Install development dependencies: `pip install -r requirements-dev.txt`
+2. Run all tests: `python -m unittest discover tests`
+3. Run tests with coverage: `python -m coverage run -m unittest discover tests`
+4. Check coverage report: `python -m coverage report`
+5. Fix any failing tests before committing
+
 ## Permissions
 Claude requires the following Bash tool permissions:
 - `pip` commands for dependency installation
-- `python` commands for running type checkers
+- `python` commands for running type checkers and unit tests
 - `mypy` commands for static type analysis


### PR DESCRIPTION
Adds comprehensive unit testing instructions to CLAUDE.md including:

- unittest framework setup and commands
- Coverage analysis instructions
- Test structure documentation
- Updated development workflow
- Modified permissions for unit testing

Resolves #111

Generated with [Claude Code](https://claude.ai/code)